### PR TITLE
add support for Alibaba Cloud KMS Secret Manager

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ A few properties has changed name overtime, we still maintain backwards compatbi
 
 ## Backends
 
-kubernetes-external-secrets supports AWS Secrets Manager, AWS System Manager, Hashicorp Vault and Azure Key Vault.
+kubernetes-external-secrets supports AWS Secrets Manager, AWS System Manager, Hashicorp Vault, Azure Key Vault and Alibaba Cloud KMS Secret Manager.
 
 ### AWS Secrets Manager
 
@@ -369,10 +369,10 @@ filesFromSecret:
 kubernetes-external-secrets supports fetching secrets from [Azure Key vault](https://azure.microsoft.com/en-ca/services/key-vault/)
 
 You will need to set these env vars in the deployment of kubernetes-external-secrets:
+
 - AZURE_TENANT_ID
 - AZURE_CLIENT_ID
 - AZURE_CLIENT_SECRET
-
 The SP configured will require get and list access policies on the AZURE_KEYVAULT_NAME.
 
 ```yml
@@ -388,6 +388,35 @@ spec:
       name: password
       property: value
 ```
+
+### Alibaba Cloud KMS Secret Manager
+
+kubernetes-external-secrets supports fetching secrets from [Alibaba Cloud KMS Secret Manager](https://www.alibabacloud.com/help/doc-detail/152001.htm)
+
+You will need to set these env vars in the deployment of kubernetes-external-secrets:
+
+- ALICLOUD_ACCESS_KEY_ID
+- ALICLOUD_ACCESS_KEY_SECRET
+- ALICLOUD_API_VERSION
+
+```yml
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: hello-service
+spec:
+  backendType: alicloudSecretsManager
+  # optional: specify role to assume using provided access key ID and access key secret when retrieving the data
+  roleArn: acs:ram::{UID}:role/demo
+  data:
+    - key: hello-credentials1
+      name: password
+    - key: hello-credentials2
+      name: username
+      # Version Stage in Alibaba Cloud KMS Secrets Manager. Optional, default value is ACSCurrent
+      versionStage: ACSCurrent
+```
+
 
 ### GCP Secret Manager
 

--- a/charts/kubernetes-external-secrets/README.md
+++ b/charts/kubernetes-external-secrets/README.md
@@ -52,6 +52,9 @@ The following table lists the configurable parameters of the `kubernetes-externa
 | `env.DISABLE_POLLING`                          | Disables backend polling and only updates secrets when ExternalSecret is modified, setting this to any value will disable polling               | `nil`                                  |
 | `envVarsFromSecret.AWS_ACCESS_KEY_ID`     | Set AWS_ACCESS_KEY_ID (from a secret) in Deployment Pod      |                                                         |
 | `envVarsFromSecret.AWS_SECRET_ACCESS_KEY` | Set AWS_SECRET_ACCESS_KEY (from a secret) in Deployment Pod  |                                                         |
+| `envVarsFromSecret.ALICLOUD_ENDPOINT`     | Set ALICLOUD_ENDPOINT for KMS Service in Deployment Pod      |                                                         |
+| `envVarsFromSecret.ALICLOUD_ACCESS_KEY_ID`     | Set ALICLOUD_ACCESS_KEY_ID (from a secret) in Deployment Pod |                                                    |
+| `envVarsFromSecret.ALICLOUD_ACCESS_KEY_SECRET` | Set ALICLOUD_ACCESS_KEY_SECRET (from a secret) in Deployment Pod  |                                               |
 | `envVarsFromSecret.AZURE_TENANT_ID`     | Set AZURE_TENANT_ID (from a secret) in Deployment Pod      |                                                         |
 | `envVarsFromSecret.AZURE_CLIENT_ID` | Set AZURE_CLIENT_ID (from a secret) in Deployment Pod  |                                                         |
 | `envVarsFromSecret.AZURE_CLIENT_SECRET` | Set AZURE_CLIENT_SECRET (from a secret) in Deployment Pod  |                                                         |

--- a/charts/kubernetes-external-secrets/values.yaml
+++ b/charts/kubernetes-external-secrets/values.yaml
@@ -19,6 +19,15 @@ env:
 #  AWS_SECRET_ACCESS_KEY:
 #    secretKeyRef: aws-credentials
 #    key: key
+#  ALICLOUD_ENDPOINT:
+#    secretKeyRef: alicloud-credentials
+#    key: endpoint
+#  ALICLOUD_ACCESS_KEY_ID:
+#    secretKeyRef: alicloud-credentials
+#    key: id
+#  ALICLOUD_ACCESS_KEY_SECRET:
+#    secretKeyRef: alicloud-credentials
+#    key: secret
 #  AZURE_TENANT_ID:
 #    secretKeyRef: azure-credentials
 #    key: tenantid

--- a/config/alicloud-config.js
+++ b/config/alicloud-config.js
@@ -1,0 +1,15 @@
+'use strict'
+
+// Alibaba Cloud expects the following four environment variables:
+// - ALICLOUD_ENDPOINT: endpoint URL http(s)://kms.{regionID}.aliyuncs.com or http(s)://kms-vpc.{regionID}.aliyuncs.com
+// - ALICLOUD_ACCESS_KEY_ID: The access key ID
+// - ALICLOUD_ACCESS_KEY_SECRET: The access key secret
+
+module.exports = {
+  credential: {
+    accessKeyId: process.env.ALICLOUD_ACCESS_KEY_ID,
+    accessKeySecret: process.env.ALICLOUD_ACCESS_KEY_SECRET,
+    endpoint: process.env.ALICLOUD_ENDPOINT,
+    type: 'access_key'
+  }
+}

--- a/config/index.js
+++ b/config/index.js
@@ -10,6 +10,7 @@ const path = require('path')
 
 const awsConfig = require('./aws-config')
 const azureConfig = require('./azure-config')
+const alicloudConfig = require('./alicloud-config')
 const gcpConfig = require('./gcp-config')
 const envConfig = require('./environment')
 const CustomResourceManager = require('../lib/custom-resource-manager')
@@ -18,6 +19,7 @@ const SystemManagerBackend = require('../lib/backends/system-manager-backend')
 const VaultBackend = require('../lib/backends/vault-backend')
 const AzureKeyVaultBackend = require('../lib/backends/azure-keyvault-backend')
 const GCPSecretsManagerBackend = require('../lib/backends/gcp-secrets-manager-backend')
+const AliCloudSecretsManagerBackend = require('../lib/backends/alicloud-secrets-manager-backend')
 
 // Get document, or throw exception on error
 // eslint-disable-next-line security/detect-non-literal-fs-filename
@@ -60,13 +62,19 @@ const gcpSecretsManagerBackend = new GCPSecretsManagerBackend({
   client: gcpConfig.gcpSecretsManager(),
   logger
 })
+const alicloudSecretsManagerBackend = new AliCloudSecretsManagerBackend({
+  credential: alicloudConfig.credential,
+  logger
+})
 const backends = {
   // when adding a new backend, make sure to change the CRD property too
   secretsManager: secretsManagerBackend,
   systemManager: systemManagerBackend,
   vault: vaultBackend,
   azureKeyVault: azureKeyVaultBackend,
-  gcpSecretsManager: gcpSecretsManagerBackend
+  gcpSecretsManager: gcpSecretsManagerBackend,
+  alicloudSecretsManager: alicloudSecretsManagerBackend
+
 }
 
 // backwards compatibility

--- a/crd.yaml
+++ b/crd.yaml
@@ -44,6 +44,7 @@ spec:
                 - vault
                 - azureKeyVault
                 - gcpSecretsManager
+                - alicloudSecretsManager
             vaultRole:
               type: string
             vaultMountPoint:
@@ -103,6 +104,10 @@ spec:
                 backendType:
                   enum:
                     - gcpSecretsManager
+            - properties:
+                backendType:
+                  enum:
+                    - alicloudSecretsManager
           anyOf:
             - required:
               - data

--- a/examples/alicloudsecretsmanager-example.yaml
+++ b/examples/alicloudsecretsmanager-example.yaml
@@ -1,0 +1,9 @@
+apiVersion: kubernetes-client.io/v1
+kind: ExternalSecret
+metadata:
+  name: secretsmanager-example
+spec:
+  backendType: alicloudSecretsManager
+  data:
+    - key: akey
+      name: password

--- a/lib/backends/alicloud-secrets-manager-backend.js
+++ b/lib/backends/alicloud-secrets-manager-backend.js
@@ -1,0 +1,52 @@
+'use strict'
+
+const KVBackend = require('./kv-backend')
+const { default: Client, GetSecretValueRequest } = require('@alicloud/kms20160120')
+/** Secrets Manager backend class. */
+class AliCloudSecretsManagerBackend extends KVBackend {
+  /**
+   * Create Secrets manager backend.
+   * @param {Object} logger - Logger for logging stuff.
+   * @param {Object} credential - Secrets manager credential.
+   */
+  constructor ({ logger, credential }) {
+    super({ logger })
+    this._credential = credential
+  }
+
+  _getClient ({ specOptions: { roleArn } }) {
+    const config = {
+      endpoint: this._credential.endpoint,
+      accessKeyId: this._credential.accessKeyId,
+      accessKeySecret: this._credential.accessKeySecret,
+      type: this._credential.type
+    }
+    if (roleArn) {
+      config.type = 'ram_role_arn'
+      config.roleArn = roleArn
+    }
+    return new Client(config)
+  }
+
+  /**
+   * Get secret property value from Alibaba Cloud KMS Secrets Manager.
+   * @param {string} key - Key used to store secret property value in Alibaba Cloud KMS Secrets Manager.
+   * @returns {Promise} Promise object representing secret property value.
+   */
+
+  async _get ({ key, specOptions: { roleArn }, keyOptions: { versionStage } }) {
+    this._logger.info(`fetching secret ${key} on version stage ${versionStage} from AliCloud Secret Manager using role ${roleArn}`)
+    const getSecretValueRequest = new GetSecretValueRequest({
+      secretName: key,
+      versionStage: versionStage
+    })
+
+    const client = this._getClient({ specOptions: { roleArn } })
+    const value = await client.getSecretValue(getSecretValueRequest)
+
+    const secret = { value: value.secretData.toString('utf-8') }
+    return JSON.stringify(secret)
+  }
+}
+
+module.exports = AliCloudSecretsManagerBackend

--- a/lib/backends/alicloud-secrets-manager-backend.test.js
+++ b/lib/backends/alicloud-secrets-manager-backend.test.js
@@ -1,0 +1,45 @@
+/* eslint-env mocha */
+'use strict'
+
+const { expect } = require('chai')
+const sinon = require('sinon')
+
+const AliCloudSecretsManagerBackend = require('./alicloud-secrets-manager-backend')
+
+describe('AliCloudSecretsManagerBackend', () => {
+  let loggerMock
+  let clientMock
+  let aliCloudSecretsManagerBackend
+
+  const secret = {
+    secretData: 'fakeSecretPropertyValue'
+  }
+  const password = '{"value":"fakeSecretPropertyValue"}'
+  const key = 'password'
+
+  beforeEach(() => {
+    loggerMock = sinon.mock()
+    loggerMock.info = sinon.stub()
+    clientMock = sinon.mock()
+    clientMock.getSecretValue = sinon.stub().returns(secret)
+
+    aliCloudSecretsManagerBackend = new AliCloudSecretsManagerBackend({
+      credential: null,
+      logger: loggerMock
+    })
+    aliCloudSecretsManagerBackend._getClient = sinon.stub().returns(clientMock)
+  })
+
+  describe('_get', () => {
+    it('returns secret property value', async () => {
+      const specOptions = {}
+      const keyOptions = {}
+      const secretPropertyValue = await aliCloudSecretsManagerBackend._get({
+        key: key,
+        specOptions,
+        keyOptions
+      })
+      expect(secretPropertyValue).equals(password)
+    })
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,152 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@alicloud/credentials": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@alicloud/credentials/-/credentials-2.1.0.tgz",
+      "integrity": "sha512-cR9AY9jBlLpRDPPkeruJ+jkOIGoYS5kToxRc0bwehA97xRaIecVQGFziLuvsmw+33nWDpCVfs8Ed8RSwcmAB8w==",
+      "requires": {
+        "@alicloud/tea-typescript": "^1.5.3",
+        "httpx": "^2.2.0",
+        "ini": "^1.3.5",
+        "kitx": "^2.0.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.12.36",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.36.tgz",
+          "integrity": "sha512-hmmypvyO/uTLFYCYu6Hlb3ydeJ11vXRxg8/WJ0E3wvwmPO0y47VqnfmXFVuWlysO0Zyj+je1Y33rQeuYkZ51GQ=="
+        },
+        "kitx": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/kitx/-/kitx-2.1.0.tgz",
+          "integrity": "sha512-C/5v9MtIX7aHGOjwn5BmrrbNkJSf7i0R5mRzmh13GSAdRqQ7bYQo/Su2pTYNylFicqKNTVX3HML9k1u8k51+pQ==",
+          "requires": {
+            "@types/node": "^12.0.2"
+          }
+        }
+      }
+    },
+    "@alicloud/endpoint-util": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@alicloud/endpoint-util/-/endpoint-util-0.0.1.tgz",
+      "integrity": "sha512-+pH7/KEXup84cHzIL6UJAaPqETvln4yXlD9JzlrqioyCSaWxbug5FUobsiI6fuUOpw5WwoB3fWAtGbFnJ1K3Yg==",
+      "requires": {
+        "@alicloud/tea-typescript": "^1.5.1",
+        "kitx": "^2.0.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.12.36",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.36.tgz",
+          "integrity": "sha512-hmmypvyO/uTLFYCYu6Hlb3ydeJ11vXRxg8/WJ0E3wvwmPO0y47VqnfmXFVuWlysO0Zyj+je1Y33rQeuYkZ51GQ=="
+        },
+        "kitx": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/kitx/-/kitx-2.1.0.tgz",
+          "integrity": "sha512-C/5v9MtIX7aHGOjwn5BmrrbNkJSf7i0R5mRzmh13GSAdRqQ7bYQo/Su2pTYNylFicqKNTVX3HML9k1u8k51+pQ==",
+          "requires": {
+            "@types/node": "^12.0.2"
+          }
+        }
+      }
+    },
+    "@alicloud/http-core-sdk": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@alicloud/http-core-sdk/-/http-core-sdk-1.0.0.tgz",
+      "integrity": "sha512-ZODX85jwCf63Fmzj+pYZq85z8+SZzNg/FL+oW1/L/sRM8oj70+1+pdG0RHynAxBXkjNYt4eLIPrBvIEeVfx+LQ==",
+      "requires": {
+        "httpx": "^2.1.3"
+      }
+    },
+    "@alicloud/kms20160120": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@alicloud/kms20160120/-/kms20160120-1.1.0.tgz",
+      "integrity": "sha512-wBpzqOgc2FrNoFTf0ZbqiLl8+2UGRM2ZrV0EhjML5z31cmsnm8ycrcDzMYucMEfYfe5PYw+nWGS6G+ePm9lKzA==",
+      "requires": {
+        "@alicloud/endpoint-util": "^0.0.1",
+        "@alicloud/http-core-sdk": "^1.0.0",
+        "@alicloud/rpc-client": "^1.0.0",
+        "@alicloud/tea-util": "^1.1.0"
+      }
+    },
+    "@alicloud/rpc-client": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@alicloud/rpc-client/-/rpc-client-1.1.0.tgz",
+      "integrity": "sha512-wDsZeifhLv343sO2I0TQPagOo9yPYGLI/tYj6YWJzqbl+P3iPtWq/QUt0rx+Pow2a7BpcaLU+mXvdiG4O5PxOg==",
+      "requires": {
+        "@alicloud/credentials": "^2.1.0",
+        "@alicloud/rpc-util": "^0.0.4",
+        "@alicloud/tea-typescript": "^1.6.0",
+        "@alicloud/tea-util": "^1.2.6"
+      }
+    },
+    "@alicloud/rpc-util": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@alicloud/rpc-util/-/rpc-util-0.0.4.tgz",
+      "integrity": "sha512-OLtZ32W1V7RK6N0wzo+BJ3VTidTfoR2fbFuL+1bHM5+mNqbfWoIvFD7jmqumQKgEI+njw8MHgQmVUTtRnpqdrQ==",
+      "requires": {
+        "@alicloud/tea-typescript": "^1",
+        "@types/xml2js": "^0.4.5",
+        "kitx": "^2.0.0",
+        "xml2js": "^0.4.22"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.12.36",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.36.tgz",
+          "integrity": "sha512-hmmypvyO/uTLFYCYu6Hlb3ydeJ11vXRxg8/WJ0E3wvwmPO0y47VqnfmXFVuWlysO0Zyj+je1Y33rQeuYkZ51GQ=="
+        },
+        "kitx": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/kitx/-/kitx-2.1.0.tgz",
+          "integrity": "sha512-C/5v9MtIX7aHGOjwn5BmrrbNkJSf7i0R5mRzmh13GSAdRqQ7bYQo/Su2pTYNylFicqKNTVX3HML9k1u8k51+pQ==",
+          "requires": {
+            "@types/node": "^12.0.2"
+          }
+        }
+      }
+    },
+    "@alicloud/tea-typescript": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@alicloud/tea-typescript/-/tea-typescript-1.6.0.tgz",
+      "integrity": "sha512-4wwX1LsYh9QryxHk220f3agFKl6aBmHv9l4TRzlHjgvZRAZzt47INnQ5sJ7gvW5/V2Jp/fpvapi5nM582RUM/A==",
+      "requires": {
+        "@types/node": "^12.0.2",
+        "httpx": "^2.2.2"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.12.36",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.36.tgz",
+          "integrity": "sha512-hmmypvyO/uTLFYCYu6Hlb3ydeJ11vXRxg8/WJ0E3wvwmPO0y47VqnfmXFVuWlysO0Zyj+je1Y33rQeuYkZ51GQ=="
+        }
+      }
+    },
+    "@alicloud/tea-util": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@alicloud/tea-util/-/tea-util-1.2.6.tgz",
+      "integrity": "sha512-eQxSnFJGa0iuChP/lhhmGbj5l2E1+qyn+LoARwLzVpSeopkHohrR3kmhs29Az5Q7UTGFbqX2Ol+YsFqgphiPtQ==",
+      "requires": {
+        "@alicloud/tea-typescript": "^1.5.1",
+        "kitx": "^2.0.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.12.36",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.36.tgz",
+          "integrity": "sha512-hmmypvyO/uTLFYCYu6Hlb3ydeJ11vXRxg8/WJ0E3wvwmPO0y47VqnfmXFVuWlysO0Zyj+je1Y33rQeuYkZ51GQ=="
+        },
+        "kitx": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/kitx/-/kitx-2.1.0.tgz",
+          "integrity": "sha512-C/5v9MtIX7aHGOjwn5BmrrbNkJSf7i0R5mRzmh13GSAdRqQ7bYQo/Su2pTYNylFicqKNTVX3HML9k1u8k51+pQ==",
+          "requires": {
+            "@types/node": "^12.0.2"
+          }
+        }
+      }
+    },
     "@azure/abort-controller": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@azure/abort-controller/-/abort-controller-1.0.1.tgz",
@@ -639,6 +785,14 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/@types/ws/-/ws-6.0.3.tgz",
       "integrity": "sha512-yBTM0P05Tx9iXGq00BbJPo37ox68R5vaGTXivs6RGh/BQ6QP5zqZDGWdAO6JbRE/iR1l80xeGAwCQS2nMV9S/w==",
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/xml2js": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.5.tgz",
+      "integrity": "sha512-yohU3zMn0fkhlape1nxXG2bLEGZRc1FeqF80RoHaYXJN7uibaauXfhzhOJr1Xh36sn+/tx21QAOf07b/xYVk1w==",
       "requires": {
         "@types/node": "*"
       }
@@ -3840,6 +3994,22 @@
         "debug": "4"
       }
     },
+    "httpx": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/httpx/-/httpx-2.2.3.tgz",
+      "integrity": "sha512-peGQDI+x5JwGvRJ+VUd2oqR4jn9G/40EsV+6hmVK7hDDvDIgshIIBEXjJJ1ZLfhxaTW8ZEKS/VMeLP3bdyhxvQ==",
+      "requires": {
+        "@types/node": "^12.0.2",
+        "debug": "^4.1.1"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "12.12.36",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.36.tgz",
+          "integrity": "sha512-hmmypvyO/uTLFYCYu6Hlb3ydeJ11vXRxg8/WJ0E3wvwmPO0y47VqnfmXFVuWlysO0Zyj+je1Y33rQeuYkZ51GQ=="
+        }
+      }
+    },
     "iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -3909,8 +4079,7 @@
     "ini": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-      "dev": true
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
       "version": "7.1.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
   "keywords": [
     "kubernetes",
     "secrets",
-    "aws"
+    "aws",
+    "alicloud",
+    "aliyun"
   ],
   "author": "GoDaddy Operating Company, LLC",
   "license": "MIT",
@@ -29,6 +31,7 @@
     "node": ">=12.0.0"
   },
   "dependencies": {
+    "@alicloud/kms20160120": "^1.1.0",
     "@azure/identity": "^1.0.2",
     "@azure/keyvault-secrets": "^4.0.2",
     "aws-sdk": "^2.628.0",


### PR DESCRIPTION
with current version only the followings are supported:
1. 'ACSCurrenit' for version stage is the default value and recommented.
2. AccessKeyId + AccessKeySecret or STS (assume a provided role name using the provided AccessKeyId and AccessKeySecret). ECS_RAM_ROLE and Kube2Ram are not supported yet.
3. secret value as plaintext - parsing secret value as a json object not yet support